### PR TITLE
Fix V730 warning from PVS-Studio Static Analyzer

### DIFF
--- a/include/CppJieba/KeywordExtractor.hpp
+++ b/include/CppJieba/KeywordExtractor.hpp
@@ -20,8 +20,9 @@ namespace CppJieba
 
             unordered_set<string> _stopWords;
         public:
-            KeywordExtractor(){};
+            KeywordExtractor() : _idfAverage(0){};
             KeywordExtractor(const string& dictPath, const string& hmmFilePath, const string& idfPath, const string& stopWordPath)
+             : _idfAverage(0)
             {
                 LIMONP_CHECK(init(dictPath, hmmFilePath, idfPath, stopWordPath));
             };


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Not all members of a class are initialized inside the constructor.
Consider inspecting: _idfAverage.